### PR TITLE
Trim '@' from name if it is present

### DIFF
--- a/plugins/fact/remember.go
+++ b/plugins/fact/remember.go
@@ -54,7 +54,8 @@ func (p *RememberPlugin) Message(message msg.Message) bool {
 		// we have a remember!
 		// look through the logs and find parts[1] as a user, if not,
 		// fuck this hoser
-		nick := parts[1]
+		// some people use @nick instead of just nick
+		nick := strings.TrimPrefix(parts[1], "@")
 		snip := strings.Join(parts[2:], " ")
 		for i := len(p.Log[message.Channel]) - 1; i >= 0; i-- {
 			entry := p.Log[message.Channel][i]


### PR DESCRIPTION
Some people use '@nick' in Slack for a prettier autocomplete UI. Catbase can't match that with a name.

'@' is not a valid character in a nickname per the Slack docs, so we won't accidentally truncate a real user name.
