### PR TITLE
quiet down the babbler

### DIFF
--- a/plugins/babbler/babbler.go
+++ b/plugins/babbler/babbler.go
@@ -121,10 +121,15 @@ func (p *BabblerPlugin) Message(message msg.Message) bool {
 		saidWhat, saidSomething = p.getBabbleWithSuffix(tokens)
 	} else if numTokens >= 2 && tokens[1] == "says-middle-out" {
 			saidWhatStart, saidSomethingStart := p.getBabbleWithSuffix(tokens)
-			saidWhatEnd, saidSomethingEnd := p.getBabble(tokens)
-			saidSomething = saidSomethingStart && saidSomethingEnd
-			if saidSomething {
-				saidWhat = saidWhatStart + " " + strings.Join(strings.Fields(saidWhatEnd)[len(tokens)-2:], " ")
+			if !saidSomethingStart || saidWhatStart == strings.Join(tokens[2:], " ") {
+				saidSomething = saidSomethingStart
+				saidWhat = saidWhatStart
+			} else {
+				saidWhatEnd, saidSomethingEnd := p.getBabble(tokens)
+				saidSomething = saidSomethingStart && saidSomethingEnd
+				if saidSomething {
+					saidWhat = saidWhatStart + " " + strings.Join(strings.Fields(saidWhatEnd)[len(tokens)-2:], " ")
+				}
 			}
 	} else if len(tokens) == 4 && strings.Index(lowercase, "initialize babbler for ") == 0 {
 		saidWhat, saidSomething = p.initializeBabbler(tokens)

--- a/plugins/babbler/babbler_test.go
+++ b/plugins/babbler/babbler_test.go
@@ -31,9 +31,9 @@ func TestBabblerNoBabbler(t *testing.T) {
 	c.config.Babbler.DefaultUsers = []string{"seabass"}
 	assert.NotNil(t, c)
 	c.Message(makeMessage("!seabass2 says"))
-	res := assert.Len(t, mb.Messages, 1)
+	res := assert.Len(t, mb.Messages, 0)
 	assert.True(t, res)
-	assert.Contains(t, mb.Messages[0], "seabass2 babbler not found")
+	// assert.Contains(t, mb.Messages[0], "seabass2 babbler not found")
 }
 
 func TestBabblerNothingSaid(t *testing.T) {
@@ -250,6 +250,21 @@ func TestBabblerMiddleOutSeed(t *testing.T) {
 	assert.True(t, res)
 	assert.Contains(t, mb.Messages[0], "it's easier to test with unique messages")
 }
+
+func TestBabblerBadMiddleOutSeed(t *testing.T) {
+	mb := bot.NewMockBot()
+	c := New(mb)
+	c.config.Babbler.DefaultUsers = []string{"seabass"}
+	assert.NotNil(t, c)
+	seabass := makeMessage("It's easier to test with unique messages")
+	seabass.User = &user.User{Name: "seabass"}
+	res := c.Message(seabass)
+	res = c.Message(makeMessage("!seabass says-middle-out anything true"))
+	assert.Len(t, mb.Messages, 1)
+	assert.True(t, res)
+	assert.Contains(t, mb.Messages[0], "seabass never said 'anything true'")
+}
+
 
 func TestBabblerBatch(t *testing.T) {
 	mb := bot.NewMockBot()

--- a/plugins/babbler/commands.go
+++ b/plugins/babbler/commands.go
@@ -28,7 +28,8 @@ func (p *BabblerPlugin) getBabble(tokens []string) (string, bool) {
 
 	if err != nil {
 		if err == NO_BABBLER {
-			return fmt.Sprintf("%s babbler not found.", who), true
+			// return fmt.Sprintf("%s babbler not found.", who), true
+			return "", false
 		}
 	} else {
 
@@ -58,7 +59,8 @@ func (p *BabblerPlugin) getBabbleWithSuffix(tokens []string) (string, bool) {
 
 	if err != nil {
 		if err == NO_BABBLER {
-			return fmt.Sprintf("%s babbler not found.", who), true
+			// return fmt.Sprintf("%s babbler not found.", who), true
+			return "", false
 		}
 	} else {
 
@@ -83,7 +85,8 @@ func (p *BabblerPlugin) getBabbleWithBookends(start, end []string) (string, bool
 
 	if err != nil {
 		if err == NO_BABBLER {
-			return fmt.Sprintf("%s babbler not found.", who), true
+			// return fmt.Sprintf("%s babbler not found.", who), true
+			return "", false
 		}
 	} else {
 


### PR DESCRIPTION
Minimize the clutter.

1) Don't print "babbler not found" anymore. If a sentence happens to have "says" as its second word, then we won't say anything about it.

2) To calm msherms down, only print the error message once when using middle-out