### PR TITLE
babbler: make recording new babbles _fast_

### DIFF
--- a/plugins/babbler/commands.go
+++ b/plugins/babbler/commands.go
@@ -17,7 +17,7 @@ func (p *BabblerPlugin) initializeBabbler(tokens []string) (string, bool) {
 func (p *BabblerPlugin) addToBabbler(babblerName, whatWasSaid string) (string, bool) {
 	babblerId, err := p.getOrCreateBabbler(babblerName)
 	if err == nil {
-		p.addToMarkovChain(babblerId, whatWasSaid)
+		go p.addToMarkovChain(babblerId, whatWasSaid)
 	}
 	return "", false
 }


### PR DESCRIPTION
This is a hack. I am just pushing the processing off into a goroutine so
that we can return as quickly as possible from a non-event as far as the
bot's interaction with users is concerned. This is potentially harmful
if we have too many goroutines blocked writing babblers (hopefully
    sqlite is configured to be thread-safe). But if we have a bunch of
    babblers writing off to disk, it's no worse than blocking for each
    one sequentially, I guess.

I am not auto-merging this PR.