### PR TITLE
fact: add reaction type facts

### DIFF
--- a/bot/mock.go
+++ b/bot/mock.go
@@ -21,8 +21,9 @@ type MockBot struct {
 
 	Cfg config.Config
 
-	Messages []string
-	Actions  []string
+	Messages  []string
+	Actions   []string
+	Reactions []string
 }
 
 func (mb *MockBot) Config() *config.Config            { return &mb.Cfg }
@@ -47,11 +48,14 @@ func (mb *MockBot) ReplyToMessage(channel, message string, replyTo msg.Message) 
 }
 func (mb *MockBot) MsgReceived(msg msg.Message)                {}
 func (mb *MockBot) EventReceived(msg msg.Message)              {}
-func (mb *MockBot) Filter(msg msg.Message, s string) string    { return "" }
+func (mb *MockBot) Filter(msg msg.Message, s string) string    { return s }
 func (mb *MockBot) LastMessage(ch string) (msg.Message, error) { return msg.Message{}, nil }
 func (mb *MockBot) CheckAdmin(nick string) bool                { return false }
 
-func (mb *MockBot) React(channel, reaction string, message msg.Message) bool { return false }
+func (mb *MockBot) React(channel, reaction string, message msg.Message) bool {
+	mb.Reactions = append(mb.Reactions, reaction)
+	return false
+}
 
 func (mb *MockBot) Edit(channel, newMessage, identifier string) bool {
 	isMessage := identifier[0] == 'm'

--- a/plugins/fact/remember_test.go
+++ b/plugins/fact/remember_test.go
@@ -50,3 +50,30 @@ func TestCornerCaseBug(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, q.Tidbit, "horse dick")
 }
+
+func TestReact(t *testing.T) {
+	msgs := []msg.Message{
+		makeMessage("user1", "!testing123 <react> jesus"),
+		makeMessage("user2", "testing123"),
+	}
+	_, p, mb := makePlugin(t)
+
+	for _, m := range msgs {
+		p.Message(m)
+	}
+	assert.Len(t, mb.Reactions, 1)
+	assert.Contains(t, mb.Reactions[0], "jesus")
+}
+
+func TestReactCantLearnSpaces(t *testing.T) {
+	msgs := []msg.Message{
+		makeMessage("user1", "!test <react> jesus christ"),
+	}
+	_, p, mb := makePlugin(t)
+
+	for _, m := range msgs {
+		p.Message(m)
+	}
+	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "not a valid")
+}


### PR DESCRIPTION
If a user creates a fact with the verb <react>, catbase will try to
react with the emojy that the user specifies. It filters things with
spaces and fixes colons, but does not check if the emojy actually
exists. There will be no feedback in this case, which should probably
get fixed but meh.

* Updated mock bot to check reactions, and do filtering correctly.
* Added a couple tests of the react functionality.