### PR TITLE
Better error message

### DIFF
--- a/plugins/reminder/reminder.go
+++ b/plugins/reminder/reminder.go
@@ -88,7 +88,7 @@ func (p *ReminderPlugin) message(kind bot.Kind, message msg.Message, args ...int
 
 			dur, err := time.ParseDuration(parts[3])
 			if err != nil {
-				p.Bot.Send(bot.Message, channel, "Easy cowboy, not sure I can parse that duration.")
+				p.Bot.Send(bot.Message, channel, "Easy cowboy, not sure I can parse that duration. Try something like '1.5h' or '2h45m'.")
 				return true
 			}
 
@@ -116,7 +116,7 @@ func (p *ReminderPlugin) message(kind bot.Kind, message msg.Message, args ...int
 				//remind who every dur for dur2 blah
 				dur2, err := time.ParseDuration(parts[5])
 				if err != nil {
-					p.Bot.Send(bot.Message, channel, "Easy cowboy, not sure I can parse that duration.")
+					p.Bot.Send(bot.Message, channel, "Easy cowboy, not sure I can parse that duration. Try something like '1.5h' or '2h45m'.")
 					return true
 				}
 

--- a/plugins/reminder/reminder_test.go
+++ b/plugins/reminder/reminder_test.go
@@ -77,7 +77,7 @@ func TestReminderParse(t *testing.T) {
 	res := c.message(makeMessage("!remind testuser in unparseable don't fail this test"))
 	assert.Len(t, mb.Messages, 1)
 	assert.True(t, res)
-	assert.Contains(t, mb.Messages[0], "Easy cowboy, not sure I can parse that duration.")
+	assert.Contains(t, mb.Messages[0], "Easy cowboy, not sure I can parse that duration. Try something like '1.5h' or '2h45m'.")
 }
 
 func TestEmptyList(t *testing.T) {


### PR DESCRIPTION
`Easy cowboy, not sure I can parse that duration. Try something like '1.5h' or '2h45m'.`