### PR TITLE
pick: add delimiter support

### DIFF
--- a/plugins/picker/picker.go
+++ b/plugins/picker/picker.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"fmt"
 	"math/rand"
 
@@ -66,8 +68,7 @@ func (p *PickerPlugin) message(c bot.Connector, kind bot.Kind, message msg.Messa
 	return true
 }
 
-var pickerListPrologue = regexp.MustCompile(`^pick[ \t]+([0-9]*)[ \t]*\{[ \t]*`)
-var pickerListItem = regexp.MustCompile(`^([^,]+),[ \t]*`)
+var pickerListPrologue = regexp.MustCompile(`^pick([^ \t]*)[ \t]+([0-9]*)[ \t]*\{[ \t]*`)
 var pickerListFinalItem = regexp.MustCompile(`^([^,}]+),?[ \t]*\}[ \t]*`)
 
 func (p *PickerPlugin) parse(body string) (int, []string, error) {
@@ -76,14 +77,26 @@ func (p *PickerPlugin) parse(body string) (int, []string, error) {
 		return 0, nil, errors.New("saddle up for a syntax error")
 	}
 
+	log.Debug().
+		Str("body", body).
+		Interface("subs", subs).
+		Msg("subs")
+
 	n := 1
+	delim := ","
 	var err error
+
 	if subs[1] != "" {
-		n, err = strconv.Atoi(subs[1])
+		delim = subs[1]
+	}
+
+	if subs[2] != "" {
+		n, err = strconv.Atoi(subs[2])
 		if err != nil {
 			return 0, nil, err
 		}
 	}
+	pickerListItem := regexp.MustCompile(`^([^` + delim + `]+)` + delim + `[ \t]*`)
 
 	var items []string
 	rest := body[len(subs[0]):]

--- a/plugins/picker/picker_test.go
+++ b/plugins/picker/picker_test.go
@@ -3,9 +3,12 @@
 package picker
 
 import (
-	"github.com/velour/catbase/plugins/cli"
 	"strings"
 	"testing"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/velour/catbase/plugins/cli"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/velour/catbase/bot"
@@ -32,6 +35,7 @@ func TestPick2(t *testing.T) {
 	assert.NotNil(t, c)
 	res := c.message(makeMessage("!pick 2 { a, b,c}"))
 	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "hot picks")
 	if !res {
 		t.Fatalf("expected a successful choice, got %q", mb.Messages[0])
 	}
@@ -44,4 +48,43 @@ func TestPickDefault(t *testing.T) {
 	_ = c.message(makeMessage("!pick { a}"))
 	assert.Len(t, mb.Messages, 1)
 	assert.Equal(t, `I've chosen "a" for you.`, mb.Messages[0])
+}
+
+func TestPickDefaultWithSeprator(t *testing.T) {
+	mb := bot.NewMockBot()
+	c := New(mb)
+	assert.NotNil(t, c)
+	_ = c.message(makeMessage("!pick { a, b, c}"))
+	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "I've chosen")
+	assert.NotContains(t, mb.Messages[0], "hot picks")
+}
+
+func TestPickDelimiter(t *testing.T) {
+	mb := bot.NewMockBot()
+	c := New(mb)
+	_ = c.message(makeMessage("!pick; {a; b}"))
+	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "I've chosen")
+	assert.NotContains(t, mb.Messages[0], "hot picks")
+	log.Debug().Str("resp", mb.Messages[0]).Msg("choose")
+}
+
+func TestPickDelimiterMulti(t *testing.T) {
+	mb := bot.NewMockBot()
+	c := New(mb)
+	_ = c.message(makeMessage("!pick; 2 {a; b}"))
+	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "hot picks")
+	log.Debug().Str("resp", mb.Messages[0]).Msg("choose")
+}
+
+func TestPickDelimiterString(t *testing.T) {
+	mb := bot.NewMockBot()
+	c := New(mb)
+	_ = c.message(makeMessage("!pick123 {a 123 b}"))
+	assert.Len(t, mb.Messages, 1)
+	assert.Contains(t, mb.Messages[0], "I've chosen")
+	assert.NotContains(t, mb.Messages[0], "hot picks")
+	log.Debug().Str("resp", mb.Messages[0]).Msg("choose")
 }


### PR DESCRIPTION
* Default is still `,`
* Can choose any string directly after pick, for example `pick- {a- b- c}`