### PR TITLE
connectors: add translation layer

### DIFF
--- a/bot/interfaces.go
+++ b/bot/interfaces.go
@@ -142,6 +142,12 @@ type Connector interface {
 
 	// Profile returns a user's information given an ID
 	Profile(string) (user.User, error)
+
+	// URL Format utility
+	URLFormat(title, url string) string
+
+	// Translate emojy to/from services
+	Emojy(string) string
 }
 
 // Plugin interface used for compatibility with the Plugin interface

--- a/bot/mock.go
+++ b/bot/mock.go
@@ -113,7 +113,8 @@ func NewMockBot() *MockBot {
 	return &b
 }
 
-func (mb *MockBot) GetPluginNames() []string      { return nil }
-func (mb *MockBot) RefreshPluginBlacklist() error { return nil }
-func (mb *MockBot) RefreshPluginWhitelist() error { return nil }
-func (mb *MockBot) GetWhitelist() []string        { return []string{} }
+func (mb *MockBot) GetPluginNames() []string           { return nil }
+func (mb *MockBot) RefreshPluginBlacklist() error      { return nil }
+func (mb *MockBot) RefreshPluginWhitelist() error      { return nil }
+func (mb *MockBot) GetWhitelist() []string             { return []string{} }
+func (mb *MockBot) URLFormat(title, url string) string { return title + url }

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ func (c *Config) Unset(key string) error {
 // Note, this is always a string. Use the SetArray for an array helper
 func (c *Config) Set(key, value string) error {
 	key = strings.ToLower(key)
+	value = strings.Trim(value, "`")
 	q := `insert into config (key,value) values (?, ?)
 			on conflict(key) do update set value=?;`
 	tx, err := c.Begin()

--- a/connectors/discord/discord.go
+++ b/connectors/discord/discord.go
@@ -219,3 +219,15 @@ func (d *Discord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate
 
 	d.event(d, bot.Message, msg)
 }
+
+func (d *Discord) Emojy(name string) string {
+	e := d.config.GetMap("discord.emojy", map[string]string{})
+	if emojy, ok := e[name]; ok {
+		return emojy
+	}
+	return name
+}
+
+func (d *Discord) URLFormat(title, url string) string {
+	return fmt.Sprintf("%s (%s)", title, url)
+}

--- a/connectors/irc/irc.go
+++ b/connectors/irc/irc.go
@@ -314,3 +314,15 @@ func (i Irc) Who(channel string) []string {
 func (i Irc) Profile(string) (user.User, error) {
 	return user.User{}, fmt.Errorf("unimplemented")
 }
+
+func (i Irc) URLFormat(title, url string) string {
+	return fmt.Sprintf("%s (%s)", title, url)
+}
+
+func (i Irc) Emojy(name string) string {
+	e := i.config.GetMap("irc.emojy", map[string]string{})
+	if emojy, ok := e[name]; ok {
+		return emojy
+	}
+	return name
+}

--- a/connectors/slack/slack.go
+++ b/connectors/slack/slack.go
@@ -734,3 +734,15 @@ func (s *Slack) Who(id string) []string {
 func (s *Slack) Profile(string) (user.User, error) {
 	return user.User{}, fmt.Errorf("unimplemented")
 }
+
+func (s *Slack) Emojy(name string) string {
+	e := s.config.GetMap("slack.emojy", map[string]string{})
+	if emojy, ok := e[name]; ok {
+		return emojy
+	}
+	return name
+}
+
+func (s *Slack) URLFormat(title, url string) string {
+	return fmt.Sprintf("<%s|%s>", url, title)
+}

--- a/connectors/slackapp/slackApp.go
+++ b/connectors/slackapp/slackApp.go
@@ -682,3 +682,17 @@ func (s *SlackApp) Profile(identifier string) (user.User, error) {
 
 	return user.User{}, fmt.Errorf("user %s not found", err)
 }
+
+func (s *SlackApp) Emojy(name string) string {
+	e := s.config.GetMap("slack.emojy", map[string]string{})
+	if emojy, ok := e[name]; ok {
+		log.Debug().Msgf("Found emoji %s for %s", emojy, name)
+		return emojy
+	}
+	log.Debug().Msgf("Found no emojy for %s", name)
+	return name
+}
+
+func (s *SlackApp) URLFormat(title, url string) string {
+	return fmt.Sprintf("<%s|%s>", url, title)
+}

--- a/plugins/aoc/aoc.go
+++ b/plugins/aoc/aoc.go
@@ -88,7 +88,8 @@ func (p *AOC) message(c bot.Connector, kind bot.Kind, message msg.Message, args 
 			}
 		}
 
-		msg := fmt.Sprintf("AoC <https://adventofcode.com/%d/leaderboard/private/view/%d|Leaderboard>:\n", year, boardId)
+		link := c.URLFormat("leaderboard", fmt.Sprintf("https://adventofcode.com/%d/leaderboard/private/view/%d", year, boardId))
+		msg := fmt.Sprintf("AoC %s:\n", link)
 		for _, m := range members {
 			if m.Stars == 0 {
 				continue
@@ -96,11 +97,11 @@ func (p *AOC) message(c bot.Connector, kind bot.Kind, message msg.Message, args 
 			trophy := ""
 			switch m.ID {
 			case goldID:
-				trophy = ":gold-trophy:"
+				trophy = c.Emojy(":gold-trophy:")
 			case silverID:
-				trophy = ":silver-trophy:"
+				trophy = c.Emojy(":silver-trophy:")
 			case bronzeID:
-				trophy = ":bronze-trophy:"
+				trophy = c.Emojy(":bronze-trophy:")
 			}
 			msg += fmt.Sprintf("%s has %d :star: for a score of %d%s\n", m.Name, m.Stars, m.LocalScore, trophy)
 		}

--- a/plugins/cli/cli.go
+++ b/plugins/cli/cli.go
@@ -117,6 +117,10 @@ func (p *CliPlugin) Send(kind bot.Kind, args ...interface{}) (string, error) {
 func (p *CliPlugin) GetEmojiList() map[string]string { return nil }
 func (p *CliPlugin) Serve() error                    { return nil }
 func (p *CliPlugin) Who(s string) []string           { return nil }
-func (s *CliPlugin) Profile(name string) (user.User, error) {
+func (p *CliPlugin) Profile(name string) (user.User, error) {
 	return user.User{}, fmt.Errorf("unimplemented")
+}
+func (p *CliPlugin) Emojy(name string) string { return name }
+func (p *CliPlugin) URLFormat(title, url string) string {
+	return fmt.Sprintf("%s (%s)", title, url)
 }


### PR DESCRIPTION
* URLs can be translated to slack/discord compatible
* Emojy have a connector-specific translation configuration
* Advent of Code plugin respects emojy and URLs
* Config can be wrapped in `` for JSON