### PR TITLE
counter: use IDs when available

### DIFF
--- a/bot/interfaces.go
+++ b/bot/interfaces.go
@@ -35,6 +35,8 @@ const (
 	SelfMessage
 	// Delete removes a message by ID
 	Delete
+	// Startup is triggered after the connector has run the Serve function
+	Startup
 )
 
 type EphemeralID string

--- a/connectors/slackapp/slackApp.go
+++ b/connectors/slackapp/slackApp.go
@@ -676,6 +676,7 @@ func (s *SlackApp) Profile(identifier string) (user.User, error) {
 	}
 
 	for _, u := range users {
+		log.Debug().Str("Name", u.Name).Str("ID", u.ID).Msgf("Looking for %s", identifier)
 		if u.Name == identifier || u.ID == identifier {
 			return user.User{
 				ID:    u.ID,

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/velour/catbase/bot/msg"
 	"github.com/velour/catbase/connectors/discord"
 
 	"github.com/velour/catbase/plugins/gpt2"
@@ -157,6 +158,8 @@ func main() {
 	if err := client.Serve(); err != nil {
 		log.Fatal().Err(err)
 	}
+
+	b.Receive(client, bot.Startup, msg.Message{})
 
 	addr := c.Get("HttpAddr", "127.0.0.1:1337")
 	log.Debug().Msgf("starting web service at %s", addr)

--- a/plugins/beers/beers_test.go
+++ b/plugins/beers/beers_test.go
@@ -28,7 +28,7 @@ func makeMessage(payload string, r *regexp.Regexp) bot.Request {
 		Kind:   bot.Message,
 		Values: values,
 		Msg: msg.Message{
-			User:    &user.User{Name: "tester"},
+			User:    &user.User{Name: "tester", ID: "id"},
 			Channel: "test",
 			Body:    payload,
 			Command: isCmd,
@@ -60,7 +60,7 @@ func makeBeersPlugin(t *testing.T) (*BeersPlugin, *bot.MockBot) {
 
 func TestCounter(t *testing.T) {
 	_, mb := makeBeersPlugin(t)
-	i, err := counter.GetUserItem(mb.DB(), "tester", "test")
+	i, err := counter.GetUserItem(mb.DB(), "tester", "id", "test")
 	if !assert.Nil(t, err) {
 		t.Log(err)
 		t.Fatal()
@@ -75,7 +75,7 @@ func TestImbibe(t *testing.T) {
 	assert.Len(t, mb.Messages, 1)
 	testMessage(b, "imbibe")
 	assert.Len(t, mb.Messages, 2)
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, it.Count)
 }
@@ -83,7 +83,7 @@ func TestEq(t *testing.T) {
 	b, mb := makeBeersPlugin(t)
 	testMessage(b, "beers = 3")
 	assert.Len(t, mb.Messages, 1)
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, it.Count)
 }
@@ -94,7 +94,7 @@ func TestEqZero(t *testing.T) {
 	testMessage(b, "beers = 0")
 	assert.Len(t, mb.Messages, 2)
 	assert.Contains(t, mb.Messages[1], "reversal of fortune")
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, it.Count)
 }
@@ -105,7 +105,7 @@ func TestBeersPlusEq(t *testing.T) {
 	assert.Len(t, mb.Messages, 1)
 	testMessage(b, "beers += 5")
 	assert.Len(t, mb.Messages, 2)
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 10, it.Count)
 }
@@ -113,11 +113,11 @@ func TestBeersPlusEq(t *testing.T) {
 func TestPuke(t *testing.T) {
 	b, mb := makeBeersPlugin(t)
 	testMessage(b, "beers += 5")
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, it.Count)
 	testMessage(b, "puke")
-	it, err = counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err = counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, it.Count)
 }
@@ -125,7 +125,7 @@ func TestPuke(t *testing.T) {
 func TestBeersReport(t *testing.T) {
 	b, mb := makeBeersPlugin(t)
 	testMessage(b, "beers += 5")
-	it, err := counter.GetUserItem(mb.DB(), "tester", itemName)
+	it, err := counter.GetUserItem(mb.DB(), "tester", "id", itemName)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, it.Count)
 	testMessage(b, "beers")

--- a/plugins/goals/goals.go
+++ b/plugins/goals/goals.go
@@ -188,7 +188,14 @@ func (p *GoalsPlugin) checkGoal(c bot.Connector, ch, what, who string) {
 		p.b.Send(c, bot.Message, ch, fmt.Sprintf("I couldn't find %s", what))
 	}
 
-	item, err := counter.GetUserItem(p.db, who, what)
+	nick, id := "", ""
+	user, err := c.Profile(who)
+	if err == nil && user.ID != "" {
+		id = user.ID
+		nick = user.Name
+	}
+
+	item, err := counter.GetUserItem(p.db, nick, id, what)
 	if err != nil {
 		p.b.Send(c, bot.Message, ch, fmt.Sprintf("I couldn't find any %s", what))
 		return


### PR DESCRIPTION
This should help alleviate user name changes, but may not fix it
entirely. Had to update beers and goals to match an ID search.

Note: this will bust badly for IRC